### PR TITLE
Show Notes Markdown Support

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -59,6 +59,7 @@ def create_app():
 
     # Register Jinja template filters
     app.jinja_env.filters["pretty_jsonify"] = utility.pretty_jsonify
+    app.jinja_env.filters["markdown"] = utility.md_to_html
 
     # Register application blueprints
     app.register_blueprint(main_bp)

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -48,6 +48,7 @@
     q.scorekeeper-description { display: inline-block; font-style: italic; }
     ul.show-all-years { list-style: none; column-count: 4;}
     .show-description, .show-notes { white-space: pre-line; }
+    .show-notes>p { margin: 0; }
     .show-repeat>a { border-bottom: none !important; }
     .show-nprlink { background-color: #3366cc; color: white; }
     .show-nprlink>a { border-bottom: none !important; color: white; }

--- a/app/templates/shows/all_details.html
+++ b/app/templates/shows/all_details.html
@@ -164,7 +164,7 @@
 <div class="row">
     <div class="col s12">
         <div class="label">Notes</div>
-        <div class="show-notes">{{ show.notes }}</div>
+        <div class="show-notes">{{ show.notes|markdown|safe }}</div>
     </div>
 </div>
 {% endif %}

--- a/app/templates/shows/details.html
+++ b/app/templates/shows/details.html
@@ -161,7 +161,7 @@
 <div class="row">
     <div class="col s12">
         <div class="label">Notes</div>
-        <div class="show-notes">{{ show.notes }}</div>
+        <div class="show-notes">{{ show.notes|markdown|safe }}</div>
     </div>
 </div>
 {% endif %}

--- a/app/utility.py
+++ b/app/utility.py
@@ -9,6 +9,7 @@ import json
 from datetime import datetime
 from dateutil import parser
 from flask import current_app
+import markdown
 import pytz
 
 
@@ -35,6 +36,11 @@ def generate_date_time_stamp(time_zone: pytz.timezone = pytz.timezone("UTC")):
     """Generate a current date/timestamp string"""
     now = datetime.now(time_zone)
     return now.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def md_to_html(text: str):
+    """Converts Markdown text into HTML"""
+    return markdown.markdown(text, output_format="html")
 
 
 def pretty_jsonify(data):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@ black==22.1.0
 Flask==2.0.2
 pytz==2021.3
 gunicorn==20.1.0
+Markdown==3.3.6
 
 wwdtm>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==2.0.2
 pytz==2021.3
 gunicorn==20.1.0
+Markdown==3.3.6
 
 wwdtm>=2.0.0


### PR DESCRIPTION
Add a new filter that uses the `Markdown` page to pass the show notes text through the Markdown converter. This will enable turning URLs into links and support rudimentary styling.