### PR TITLE
Simplify 500 error handler

### DIFF
--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -15,9 +15,4 @@ def not_found(error):
 
 def handle_exception(error):
     """Handle exceptions in a slightly more graceful manner"""
-    # Pass through any HTTP errors and exceptions
-    if isinstance(error, HTTPException):
-        return error
-
-    # Handle everything else with a basic 500 error page
     return render_template("errors/500.html"), 500

--- a/app/templates/errors/500.html
+++ b/app/templates/errors/500.html
@@ -4,7 +4,4 @@
 {% block content %}
 <h1>Oops...</h1>
 <p>Something went terrible wrong!</p>
-
-<h2>Error Details</h2>
-<pre class="traceback">{{ error_traceback }}</pre>
 {% endblock %}

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2022 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.0.0-rc.2"
+APP_VERSION = "5.0.0-rc.3"


### PR DESCRIPTION
Reduce the 500 error handler logic to just render the errors/500.html template and return status code 500.