### PR TITLE
Bump required version for wwdtm to 2.0.2 to fix guest/panelist score bug

### DIFF
--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2022 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.0.0-rc.3"
+APP_VERSION = "5.0.0-rc.4"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ pytz==2021.3
 gunicorn==20.1.0
 Markdown==3.3.6
 
-wwdtm>=2.0.0
+wwdtm>=2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pytz==2021.3
 gunicorn==20.1.0
 Markdown==3.3.6
 
-wwdtm>=2.0.0
+wwdtm>=2.0.2


### PR DESCRIPTION
Require wwdtm version 2.0.2, which includes a fix to revert the guest and panelist score return value behavior back to the logic used in libwwdtm to prevent unexpected `NULL` values instead of returning `0`.