### PR TITLE
Fix incorrect redirect in shows.year_all()

### DIFF
--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -174,7 +174,7 @@ def year_all(year: int):
         database_connection.close()
 
         if not shows:
-            return redirect_url(url_for("shows.index"), year=year)
+            return redirect_url(url_for("shows.index"))
 
         return render_template(
             "shows/year_all.html",

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2022 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.0.0-rc.5"
+APP_VERSION = "5.0.0-rc.6"


### PR DESCRIPTION
Removed the unnecessary `year=year` parameter in one of the `url_for("show.index")` calls that caused it to error out.