### PR TITLE
Update Site History and About Pages

### DIFF
--- a/app/templates/pages/about.html
+++ b/app/templates/pages/about.html
@@ -42,7 +42,7 @@
     The source code for this site is released under the terms of 
     <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache
     License 2.0</a> and is available on
-    <a href="https://github.com/questionlp/stats.wwdt.me">GitHub</a>.
+    <a href="https://github.com/questionlp/stats.wwdt.me_v5">GitHub</a>.
 </p>
 
 <h2>Acknowledgments</h2>

--- a/app/templates/pages/site_history.html
+++ b/app/templates/pages/site_history.html
@@ -142,4 +142,21 @@
     provide a link at the bottom to get a full detail view of all items. This
     was done to reduce overall clutter.
 </p>
+
+<h2>Version 5</h2>
+
+<p>
+    The new version brings two big changes behind the scenes: switching to
+    Version 2 of the Wait Wait Stats Library
+    (<a href="https://github.com/questionlp/wwdtm">wwdtm</a>) and making use
+    of Flask Blueprints to make the application code more modular and easier
+    to maintain.
+</p>
+
+<p>
+    While neither of those changes translate to anything visible in
+    the site's front-end, the Materialize version was bumped from 1.0.0 to
+    1.1.0-alpha. Even though it is an alpha release of the framework, it does
+    fix some issues and also includes some security fixes.
+</p>
 {% endblock %}

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2022 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.0.0"
+APP_VERSION = "5.0.1"


### PR DESCRIPTION
Add a blurb about version 5.0 in the Site History page and update Github project repository link in the About page