### PR TITLE
Bump versions of Flask, pytz and wwdtm

### DIFF
--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2022 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.0.2"
+APP_VERSION = "5.0.3"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,9 +3,9 @@ pycodestyle==2.8.0
 pytest==6.2.5
 black==22.1.0
 
-Flask==2.0.2
-pytz==2021.3
+Flask==2.1.1
+pytz==2022.1
 gunicorn==20.1.0
 Markdown==3.3.6
 
-wwdtm>=2.0.2
+wwdtm>=2.0.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ pytz==2022.1
 gunicorn==20.1.0
 Markdown==3.3.6
 
-wwdtm>=2.0.4
+wwdtm==2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Flask==2.0.2
-pytz==2021.3
+Flask==2.1.1
+pytz==2022.1
 gunicorn==20.1.0
 Markdown==3.3.6
 
-wwdtm>=2.0.2
+wwdtm>=2.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pytz==2022.1
 gunicorn==20.1.0
 Markdown==3.3.6
 
-wwdtm>=2.0.4
+wwdtm>=2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pytz==2022.1
 gunicorn==20.1.0
 Markdown==3.3.6
 
-wwdtm>=2.0.5
+wwdtm==2.0.5


### PR DESCRIPTION
Bump versions of Flask to 2.11, pytz to 2022.1 and wwdtm to 2.0.5